### PR TITLE
make waiting for volume init optional in case of fat volumes

### DIFF
--- a/roles/eseries/library/netapp_e_volume.py
+++ b/roles/eseries/library/netapp_e_volume.py
@@ -99,6 +99,7 @@ EXAMPLES = '''
         api_username: "{{ netapp_api_username }}"
         api_password: "{{ netapp_api_password }}"
         validate_certs: "{{ netapp_api_validate_certs }}"
+        wait_for_volume_init: "{{ wait_for_volume_init }}"
       when: check_volume
 '''
 RETURN = '''
@@ -202,6 +203,9 @@ class NetAppESeriesVolume(object):
             self.thin_volume_max_repo_size = self.size
 
         self.validate_certs = p['validate_certs']
+        self.wait_init = False
+        if not p['thin_provision']:
+            self.wait_init = p['wait_for_volume_init']
 
         try:
             self.api_usr = p['api_username']
@@ -439,29 +443,30 @@ class NetAppESeriesVolume(object):
 
             self.debug('polling for completion...')
 
-            while True:
-                try:
-                    (rc, resp) = request(self.api_url + "/storage-systems/%s/volumes/%s/expand" % (self.ssid,
-                                                                                                   self.volume_detail[
-                                                                                                       'id']),
-                                         method='GET', url_username=self.api_usr, url_password=self.api_pwd,
-                                         validate_certs=self.validate_certs)
-                except Exception:
-                    err = get_exception()
-                    self.module.fail_json(
-                        msg="Failed to get volume expansion progress.  Volume [%s].  Array Id [%s]. Error[%s]." % (
-                            self.name, self.ssid, str(err)))
+            if self.wait_init:
+                while True:
+                    try:
+                        (rc, resp) = request(self.api_url + "/storage-systems/%s/volumes/%s/expand" % (self.ssid,
+                                                                                                       self.volume_detail[
+                                                                                                           'id']),
+                                             method='GET', url_username=self.api_usr, url_password=self.api_pwd,
+                                             validate_certs=self.validate_certs)
+                    except Exception:
+                        err = get_exception()
+                        self.module.fail_json(
+                            msg="Failed to get volume expansion progress.  Volume [%s].  Array Id [%s]. Error[%s]." % (
+                                self.name, self.ssid, str(err)))
 
-                action = resp['action']
-                percent_complete = resp['percentComplete']
+                    action = resp['action']
+                    percent_complete = resp['percentComplete']
 
-                self.debug('expand action %s, %s complete...' % (action, percent_complete))
+                    self.debug('expand action %s, %s complete...' % (action, percent_complete))
 
-                if action == 'none':
-                    self.debug('expand complete')
-                    break
-                else:
-                    time.sleep(5)
+                    if action == 'none':
+                        self.debug('expand complete')
+                        break
+                    else:
+                        time.sleep(5)
 
     def apply(self):
         changed = False


### PR DESCRIPTION
Hi, 

Currently the script and hence Ansible playbook waits for a long time due to the while loop [here](https://github.com/NetApp/eseries-stk/blob/54e1f74c0f242651def25aee478cd40027b37f57/roles/eseries/library/netapp_e_volume.py#L442), this may be made optional and left to the user if they want to wait for the volume initialisation, the default behaviour while creating a volume is to NOT wait for init but while expansion we are making user wait for INIT. This PR fixes the same by making init optional via `wait_for_volume_init` flag.